### PR TITLE
Remove reference to IE8 from docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ ampersand-sync will call ajaxConfig on your collection before it makes the reque
 
 ajaxConfig can either be an object, or a function that returns an object, with the following options:
 
-* `useXDR` [boolean]: (applies to IE8/9 only with cross domain requests): signifies that this is a cross-domain request and that IE should use it's XDomainRequest object. This is required if you're making cross-domain requests and want to support IE8/9). Note that XDR doesn't support headers/withCredentials.
+* `useXDR` [boolean]: (applies to IE9 only with cross domain requests): signifies that this is a cross-domain request and that IE should use it's XDomainRequest object. This is required if you're making cross-domain requests and want to support IE9). Note that XDR doesn't support headers/withCredentials.
 * `headers` [object]: any extra headers to send with the request.
 * `xhrFields` [object]: any fields to set directly on the [XHR](https://developer.mozilla.org/en/docs/Web/API/XMLHttpRequest) request object, most typically:
     * `withCredentials` [boolean]: whether to send cross domain requests with authorization headers/cookies. Useful if you're making cross sub-domain requests with a root-domain auth cookie.


### PR DESCRIPTION
Since ampersand does not support IE8, mentioning it in the docs is a little misleading. (Also see AmpersandJS/ampersand-model#24)
